### PR TITLE
Feat/OAuth

### DIFF
--- a/src/main/java/nfteen/dondon/dondon/oauth/config/CorsMvcConfig.java
+++ b/src/main/java/nfteen/dondon/dondon/oauth/config/CorsMvcConfig.java
@@ -1,5 +1,6 @@
 package nfteen.dondon.dondon.oauth.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -7,11 +8,14 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CorsMvcConfig implements WebMvcConfigurer {
 
+    @Value("${app.frontend.redirect-url}")
+    private String frontendRedirectUrl;
+
     @Override
     public void addCorsMappings(CorsRegistry corsRegistry) {
 
         corsRegistry.addMapping("/**")
                 .exposedHeaders("Set-Cookie")
-                .allowedOrigins("http://localhost:3000");
+                .allowedOrigins(frontendRedirectUrl);
     }
 }

--- a/src/main/java/nfteen/dondon/dondon/oauth/config/handler/OAuth2FailureHandler.java
+++ b/src/main/java/nfteen/dondon/dondon/oauth/config/handler/OAuth2FailureHandler.java
@@ -1,0 +1,24 @@
+package nfteen.dondon.dondon.oauth.config.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write("{\"error\": \"Unauthorized\", \"message\": \"OAuth2 인증 실패\"}");
+    }
+}
+
+

--- a/src/main/java/nfteen/dondon/dondon/oauth/controller/OAuthController.java
+++ b/src/main/java/nfteen/dondon/dondon/oauth/controller/OAuthController.java
@@ -22,10 +22,10 @@ public class OAuthController {
         try {
             ResponseCookie deleteCookie = ResponseCookie.from("access_token", "")
                     .httpOnly(true)
-                    .secure(false)
+                    .secure(true)
                     .path("/")
                     .maxAge(0) // 즉시 삭제
-                    .sameSite("Lax")
+                    .sameSite("None")
                     .build();
             response.addHeader("Set-Cookie", deleteCookie.toString());
 

--- a/src/main/java/nfteen/dondon/dondon/oauth/controller/OAuthController.java
+++ b/src/main/java/nfteen/dondon/dondon/oauth/controller/OAuthController.java
@@ -1,9 +1,9 @@
 package nfteen.dondon.dondon.oauth.controller;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,13 +20,14 @@ public class OAuthController {
     @GetMapping("/logout")
     public ResponseEntity<Map<String, String>> logout(HttpServletResponse response) {
         try {
-            Cookie cookie = new Cookie("access_token", null);
-            cookie.setHttpOnly(true);
-            cookie.setPath("/");
-            cookie.setMaxAge(0);
-            cookie.setSecure(true);
-            
-            response.addCookie(cookie);
+            ResponseCookie deleteCookie = ResponseCookie.from("access_token", "")
+                    .httpOnly(true)
+                    .secure(false)
+                    .path("/")
+                    .maxAge(0) // 즉시 삭제
+                    .sameSite("Lax")
+                    .build();
+            response.addHeader("Set-Cookie", deleteCookie.toString());
 
             return ResponseEntity.noContent().build();
         } catch (Exception e) {

--- a/src/main/java/nfteen/dondon/dondon/oauth/service/CustomSuccessHandler.java
+++ b/src/main/java/nfteen/dondon/dondon/oauth/service/CustomSuccessHandler.java
@@ -42,10 +42,10 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         ResponseCookie cookie = ResponseCookie.from("access_token", token)
                 .httpOnly(true)
-                .secure(false)
+                .secure(true)
                 .path("/")
                 .maxAge(60 * 60) // 1시간
-                .sameSite("Lax")
+                .sameSite("None")
                 .build();
         response.addHeader("Set-Cookie", cookie.toString());
 

--- a/src/main/java/nfteen/dondon/dondon/oauth/service/CustomSuccessHandler.java
+++ b/src/main/java/nfteen/dondon/dondon/oauth/service/CustomSuccessHandler.java
@@ -1,12 +1,12 @@
-package nfteen.dondon.dondon.oauth;
+package nfteen.dondon.dondon.oauth.service;
 
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import nfteen.dondon.dondon.oauth.dto.CustomOAuth2User;
 import nfteen.dondon.dondon.oauth.jwt.JWTUtil;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -22,10 +22,13 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     private final JWTUtil jwtUtil;
 
+    @Value("${app.frontend.redirect-url}")
+    private String frontendRedirectUrl;
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
-                                        Authentication authentication) throws IOException, ServletException {
+                                        Authentication authentication) throws IOException {
 
         //OAuth2User
         CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
@@ -35,20 +38,21 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
         String role = iterator.hasNext() ? iterator.next().getAuthority() : "USER";
 
+        String token = jwtUtil.createJwt(username, role, 60 * 60 * 1000L);
 
-        String token = jwtUtil.createJwt(username, role,  60 * 60 * 1000L);
+        ResponseCookie cookie = ResponseCookie.from("access_token", token)
+                .httpOnly(true)
+                .secure(false)
+                .path("/")
+                .maxAge(60 * 60) // 1시간
+                .sameSite("Lax")
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
 
-        response.addCookie(createCookie("access_token", token));
-        response.sendRedirect("http://localhost:3000/");
+        response.sendRedirect(frontendRedirectUrl);
+
+        // 프론트 리다이렉트
+        response.sendRedirect(frontendRedirectUrl);
     }
-
-    private Cookie createCookie(String key, String value){
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge(60*60);
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-
-        return cookie;
-    };
 }
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,5 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 
 spring.jwt.secret=${SECRET_KEY}
+
+app.frontend.redirect-url=${FRONTEND_REDIRECT_URL}


### PR DESCRIPTION
## 💡 PR 요약
> 구글 OAuth 로그인 시 JWT 토큰 발급 문제를 수정했습니다.
+ 로그인 성공 후 access_token이 응답에 포함되도록 개선
+ 하드코딩된 프론트엔드 URL을 외부 설정으로 변경
+ ResponseCookie 적용으로 안전하게 쿠키 전달
Resolves: #4 

## 📋 작업 내용
> ResponseCookie로 access token 설정
> 프론트엔드 리다이렉트 URL 외부화

## ✅ 체크리스트
- [x] OAuth2 로그인 시 access_token 쿠키 정상 발급 확인
- [ ] 로그아웃 시 쿠키 정상 삭제 확인
